### PR TITLE
Fix listing update logic

### DIFF
--- a/python-flask/generate_random_listings.py
+++ b/python-flask/generate_random_listings.py
@@ -14,7 +14,8 @@ if __name__ == "__main__":
     for i in range(10):
         faker = Faker()
         locale = faker.random_element(["fr-FR", "de-DE", "nl-BE"])
-        listing = factories.entties.Listing(locale).build()
+        # typo fixed: factories.entties does not exist
+        listing = factories.entities.Listing(locale).build()
         print(listing.json(ensure_ascii=False))
 
     logger.info("done")

--- a/python-flask/listingapi/adapters/sql_alchemy_listing_repository/sql_alchemy_listing_repository.py
+++ b/python-flask/listingapi/adapters/sql_alchemy_listing_repository/sql_alchemy_listing_repository.py
@@ -31,12 +31,22 @@ class SqlAlchemyListingRepository(ports.ListingRepository):
         existing_listing = self.db_session.get(models.ListingModel, listing_id)
         if existing_listing is None:
             raise exceptions.ListingNotFound
-        self.db_session.delete(existing_listing)
-
+        # update the existing record instead of deleting it in order to keep
+        # the original creation date
         listing_model = mappers.ListingMapper.from_entity_to_model(listing)
-        listing_model.id = listing_id
-        self.db_session.add(listing_model)
+        existing_listing.name = listing_model.name
+        existing_listing.street_address = listing_model.street_address
+        existing_listing.postal_code = listing_model.postal_code
+        existing_listing.city = listing_model.city
+        existing_listing.country = listing_model.country
+        existing_listing.description = listing_model.description
+        existing_listing.building_type = listing_model.building_type
+        existing_listing.price = listing_model.price
+        existing_listing.surface_area_m2 = listing_model.surface_area_m2
+        existing_listing.rooms_count = listing_model.rooms_count
+        existing_listing.bedrooms_count = listing_model.bedrooms_count
+        existing_listing.contact_phone_number = listing_model.contact_phone_number
         self.db_session.commit()
 
-        listing_dict = mappers.ListingMapper.from_model_to_dict(listing_model)
+        listing_dict = mappers.ListingMapper.from_model_to_dict(existing_listing)
         return listing_dict


### PR DESCRIPTION
## Summary
- preserve `created_date` when updating listings
- fix typo in listing generator script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884ef13e7648325af6b170e178d24f8